### PR TITLE
Relocate shaded dependencies to own namespace (#24)

### DIFF
--- a/Logger-BungeeCord/pom.xml
+++ b/Logger-BungeeCord/pom.xml
@@ -49,6 +49,26 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.zaxxer</pattern>
+                            <shadedPattern>me.prism3.com.zaxxer</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.slf4j</pattern>
+                            <shadedPattern>me.prism3.org.slf4j</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.mariadb</pattern>
+                            <shadedPattern>me.prism3.org.mariadb</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.mysql</pattern>
+                            <shadedPattern>me.prism3.com.mysql</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
             </plugin>
         </plugins>
         <resources>

--- a/Logger-Spigot/pom.xml
+++ b/Logger-Spigot/pom.xml
@@ -43,6 +43,26 @@
                             <pattern>de.jeff_media.updatechecker</pattern>
                             <shadedPattern>me.prism3.updatechecker</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>com.zaxxer</pattern>
+                            <shadedPattern>me.prism3.com.zaxxer</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.slf4j</pattern>
+                            <shadedPattern>me.prism3.org.slf4j</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.mariadb</pattern>
+                            <shadedPattern>me.prism3.org.mariadb</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.mysql</pattern>
+                            <shadedPattern>me.prism3.com.mysql</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>io.github.cdimascio</pattern>
+                            <shadedPattern>me.prism3.io.github.cdimascio</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/Logger-Velocity/pom.xml
+++ b/Logger-Velocity/pom.xml
@@ -90,8 +90,19 @@
                     <relocations>
                         <relocation>
                             <pattern>org.bstats</pattern>
-                            <!-- Replace this with your package! -->
-                            <shadedPattern>me.prism3</shadedPattern>
+                            <shadedPattern>me.prism3.org.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.zaxxer</pattern>
+                            <shadedPattern>me.prism3.com.zaxxer</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.mariadb</pattern>
+                            <shadedPattern>me.prism3.org.mariadb</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.mysql</pattern>
+                            <shadedPattern>me.prism3.com.mysql</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -163,6 +174,13 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>4.0.3</version>
+            <exclusions>
+                <!-- Included in Velocity -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
This fixes the bug in the Improving branch, but it does not affect the PostgreSQL branch. I'll leave it to you to fix this in the PostgreSQL branch too.

Note that SQLite cannot be relocated because it uses JNI. Because of this, using an own copy of SQLite is considered impossible in plugins. If you need to use SQLite I suggest using the version of SQLite bundled with the server implementation. Note that Velocity does not bundle SQLite, however.