### PR TITLE
Added HikariCP as a dependency

### DIFF
--- a/Logger-Spigot/pom.xml
+++ b/Logger-Spigot/pom.xml
@@ -282,6 +282,14 @@
             <artifactId>postgresql</artifactId>
             <version>42.4.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>3.4.5</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- DotEnv -->
         <dependency>
             <groupId>io.github.cdimascio</groupId>


### PR DESCRIPTION
When this plugin shaded AdvancedBan, it also shaded its dependencies, now as AB is not shaded, their dependencies aren't shaded either.
Fix for https://github.com/ExceptedPrism3/Logger/pull/31#issuecomment-1355081690
Maybe other dependencies have to be added too in case of another error.